### PR TITLE
Round lineHeight so it is an integer value

### DIFF
--- a/components/panza/Base/TextBase.js
+++ b/components/panza/Base/TextBase.js
@@ -18,7 +18,7 @@ const size = (fontSize, fontSizes, lineHeight, lineHeights, lineHeightAddition) 
   // 0, 1, 2, 3, 4, 5, 6
   if (typeof fontSize === 'number') {
     style.fontSize = fontSizes[fontSize]
-    style.lineHeight = fontSizes[fontSize] * lineHeights[lineHeight] + lineHeightAddition
+    style.lineHeight = Math.round(fontSizes[fontSize] * lineHeights[lineHeight] + lineHeightAddition)
   }
 
   return style


### PR DESCRIPTION
If `lineHeight` is not an integer value, Android will throw `Error while updating property 'lineHeight' in shadow node of type RCTText.

See here: https://github.com/facebook/react-native/issues/7877